### PR TITLE
fixed single " in condition

### DIFF
--- a/simpleSqlParser.js
+++ b/simpleSqlParser.js
@@ -406,7 +406,7 @@
 			tokenValue += this.currentChar;
 			this.readNextChar();
 
-			while (this.currentChar != quote) {
+			while (this.currentChar != quote && this.currentChar != "") {
 				tokenValue += this.currentChar;
 				this.readNextChar();
 			}


### PR DESCRIPTION
Having a non-valid string (missing 2nd quote) in a condition caused the program to stuck in a loop.

E.g::

``` javascript
simpleSqlParser.sql2ast('SELECT * FROM foo where "a')
```
