### PR TITLE
Added support for `INSERT INTO foo SET bar=1234, foo=5678`

### DIFF
--- a/src/sql2ast.js
+++ b/src/sql2ast.js
@@ -506,6 +506,21 @@ var insertParser = seq(
 	};
 });
 
+
+// INSERT SET parser
+var insertSetParser = seq(
+	regex(/INSERT INTO/i).skip(optWhitespace).then(tableListExpression),
+	optWhitespace,
+	regex(/SET\s?/i).skip(optWhitespace).then(assignList)
+).map(function(node) {
+	return {
+		type: 'insert',
+		into: node[0],
+		values: node[2],
+	};
+});
+
+
 var updateParser = seq(
 	regex(/UPDATE/i).skip(optWhitespace).then(tableListExpression),
 	optWhitespace,


### PR DESCRIPTION
v2 branch already had support for 

```
INSERT INTO foo ( a, b, c) VALUES ( 123, 456, 789 )
```

I've added support for this format

```
INSERT INTO foo SET bar=1234, foo=5678
```

Not sure if I've done it in the best way though, it feels a bit clumsy. Any feedback? 
